### PR TITLE
修复 终端，合成计划终端，置顶器

### DIFF
--- a/src/main/java/me/ddggdd135/slimeae/utils/ItemUtils.java
+++ b/src/main/java/me/ddggdd135/slimeae/utils/ItemUtils.java
@@ -779,8 +779,9 @@ public class ItemUtils {
             List<String> lore = result.getLore();
             if (lore != null) {
                 List<String> finalLore = lore;
-                NBT.modify(itemStack, x -> {
-                    x.getStringList(SOURCE_LORE_KEY).addAll(finalLore);
+                NBT.modify(result, x -> {
+                     x.getStringList(SOURCE_LORE_KEY).clear();
+                     x.getStringList(SOURCE_LORE_KEY).addAll(finalLore);
                 });
             }
 
@@ -789,7 +790,7 @@ public class ItemUtils {
             lore.add("");
             lore.add("&e物品数量 " + amount);
             if (addPinnedLore) lore.add("&e===已置顶===");
-            itemStack.setLore(CMIChatColor.translate(lore));
+            result.setLore(CMIChatColor.translate(lore));
         }
 
         NBT.modify(result, x -> {


### PR DESCRIPTION
1. 修复了终端里物品lore超出限制的问题。
2. 修复了合成计划终端中置顶位置和合成配方不对应的问题.
3. 预计在未来提交中删除多余的注释。