### PR TITLE
合成任务终端添加材料显示

### DIFF
--- a/src/main/java/me/ddggdd135/slimeae/core/slimefun/terminals/MECraftPlanningTerminal.java
+++ b/src/main/java/me/ddggdd135/slimeae/core/slimefun/terminals/MECraftPlanningTerminal.java
@@ -29,7 +29,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import javax.annotation.Nonnull;
 import java.util.*;
-import java.util.logging.Logger;
 
 public class MECraftPlanningTerminal extends METerminal {
 
@@ -67,10 +66,10 @@ public class MECraftPlanningTerminal extends METerminal {
         int page = fuckPage(block, recipeEntries.size());
 
         // 菜单展示逻辑
-        displayPage(blockMenu, recipeEntries, page, info, block, player);
+        displayPage(blockMenu, recipeEntries, page, info, block);
     }
 
-    private void displayPage(BlockMenu menu, List<RecipeEntry> entries, int page, NetworkInfo info, Block block, Player player) {
+    private void displayPage(BlockMenu menu, List<RecipeEntry> entries, int page, NetworkInfo info, Block block) {
         int slotPerPage = getDisplaySlots().length;
         int start = page * slotPerPage;
         int end = Math.min(start + slotPerPage, entries.size());
@@ -85,12 +84,12 @@ public class MECraftPlanningTerminal extends METerminal {
                 continue;
             }
             RecipeEntry entry = entries.get(entryIndex);
-            setupDisplayItem(menu, slot, entry, info, block, player);
+            setupDisplayItem(menu, slot, entry, info, block);
         }
 
     }
 
-    private void setupDisplayItem(BlockMenu menu, int slot, RecipeEntry entry, NetworkInfo info, Block block, Player player) {
+    private void setupDisplayItem(BlockMenu menu, int slot, RecipeEntry entry, NetworkInfo info, Block block) {
         ItemStack itemStack = entry.getItemStack().getKey();
         if (itemStack == null || itemStack.getType().isAir()) return;
         CraftingRecipe recipe = entry.getRecipe();

--- a/src/main/java/me/ddggdd135/slimeae/core/slimefun/terminals/MECraftPlanningTerminal.java
+++ b/src/main/java/me/ddggdd135/slimeae/core/slimefun/terminals/MECraftPlanningTerminal.java
@@ -56,9 +56,10 @@ public class MECraftPlanningTerminal extends METerminal {
         Set<CraftingRecipe> recipes = info.getRecipes();
         ArrayList<RecipeEntry> recipeEntries = createRecipeEntries(recipes);
 
-        // 过滤逻辑
+        // 过滤逻辑,排序
         String filter = getFilter(block).toLowerCase(Locale.ROOT);
         filterRecipeEntries(recipeEntries, player, filter);
+        recipeEntries.sort(Comparator.comparing(RecipeEntry::getItemStack, getSort(block)));
 
         // 置顶处理
         if (filter.isEmpty()) applyPinnedItems(player, recipeEntries);

--- a/src/main/java/me/ddggdd135/slimeae/core/slimefun/terminals/MECraftPlanningTerminal.java
+++ b/src/main/java/me/ddggdd135/slimeae/core/slimefun/terminals/MECraftPlanningTerminal.java
@@ -10,6 +10,8 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import java.util.*;
+import javax.annotation.Nonnull;
 import me.ddggdd135.guguslimefunlib.api.AEMenu;
 import me.ddggdd135.guguslimefunlib.libraries.colors.CMIChatColor;
 import me.ddggdd135.slimeae.SlimeAEPlugin;
@@ -26,9 +28,6 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-
-import javax.annotation.Nonnull;
-import java.util.*;
 
 public class MECraftPlanningTerminal extends METerminal {
 
@@ -86,7 +85,6 @@ public class MECraftPlanningTerminal extends METerminal {
             RecipeEntry entry = entries.get(entryIndex);
             setupDisplayItem(menu, slot, entry, info, block);
         }
-
     }
 
     private void setupDisplayItem(BlockMenu menu, int slot, RecipeEntry entry, NetworkInfo info, Block block) {
@@ -140,8 +138,8 @@ public class MECraftPlanningTerminal extends METerminal {
             try {
                 int amount = Integer.parseInt(msg);
                 if (amount > NetworkInfo.getMaxCraftingAmount()) {
-                    player.sendMessage(CMIChatColor.translate(
-                            "&c&l一次最多只能合成" + NetworkInfo.getMaxCraftingAmount() + "个物品"));
+                    player.sendMessage(
+                            CMIChatColor.translate("&c&l一次最多只能合成" + NetworkInfo.getMaxCraftingAmount() + "个物品"));
                     return;
                 }
                 if (amount <= 0) {
@@ -152,7 +150,7 @@ public class MECraftPlanningTerminal extends METerminal {
                 AutoCraftingSession session = new AutoCraftingSession(info, recipeEntry.getRecipe(), amount);
                 session.refreshGUI(45, false);
                 AEMenu menu = session.getMenu();
-                int[] borders = new int[]{45, 46, 48, 49, 50, 52, 53};
+                int[] borders = new int[] {45, 46, 48, 49, 50, 52, 53};
                 int acceptSlot = 47;
                 int cancelSlot = 51;
                 for (int slot1 : borders) {
@@ -181,11 +179,9 @@ public class MECraftPlanningTerminal extends METerminal {
                 player.sendMessage(CMIChatColor.translate("&c&l无效的数字"));
             } catch (NoEnoughMaterialsException e) {
                 player.sendMessage(CMIChatColor.translate("&c&l没有足够的材料:"));
-                for (Map.Entry<ItemStack, Long> entry :
-                        e.getMissingMaterials().entrySet()) {
+                for (Map.Entry<ItemStack, Long> entry : e.getMissingMaterials().entrySet()) {
                     String itemName = ItemUtils.getItemName(entry.getKey());
-                    player.sendMessage(
-                            CMIChatColor.translate("  &e- &f" + itemName + " &cx " + entry.getValue()));
+                    player.sendMessage(CMIChatColor.translate("  &e- &f" + itemName + " &cx " + entry.getValue()));
                 }
             } catch (Exception e) {
                 player.sendMessage(CMIChatColor.translate("&c&l" + e.getMessage()));

--- a/src/main/java/me/ddggdd135/slimeae/utils/RecipeUtils.java
+++ b/src/main/java/me/ddggdd135/slimeae/utils/RecipeUtils.java
@@ -35,11 +35,7 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecip
 import me.sfiguz7.transcendence.lists.TEItems;
 import me.sfiguz7.transcendence.lists.TERecipeType;
 import org.bukkit.Bukkit;
-import org.bukkit.inventory.CookingRecipe;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.Recipe;
-import org.bukkit.inventory.ShapedRecipe;
-import org.bukkit.inventory.ShapelessRecipe;
+import org.bukkit.inventory.*;
 
 public class RecipeUtils {
     public static final Map<RecipeType, SlimefunItem> SUPPORTED_RECIPE_TYPES = new HashMap<>();
@@ -133,6 +129,11 @@ public class RecipeUtils {
                 return new CraftingRecipe(getCraftType(entry.getKey()), input1, getOutputs(entry.getKey(), input1));
             }
         }
+
+        // 校验输入中是否包含粘液物品，粘液物品不应该用原版配方合成
+        boolean inputHasSimi =
+                Arrays.stream(input).filter(Objects::nonNull).anyMatch(item -> SlimefunItem.getByItem(item) != null);
+        if (inputHasSimi) return null;
 
         Recipe minecraftRecipe =
                 Bukkit.getCraftingRecipe(input, Bukkit.getWorlds().get(0));


### PR DESCRIPTION
1. 修复合成任务终端搜索时，空栏可以点击的问题
2. 修复多个相同输出配方被合并
3. #54
4. 完善了合成任务终端的置顶，搜索功能
5. 修复粘液材料合成原版物品bug