### PR TITLE
Fix hologram removal order on block break

### DIFF
--- a/src/main/java/me/ddggdd135/slimeae/core/slimefun/MEConversionMonitor.java
+++ b/src/main/java/me/ddggdd135/slimeae/core/slimefun/MEConversionMonitor.java
@@ -221,10 +221,10 @@ public class MEConversionMonitor extends SlimefunItem implements IMEObject, Holo
 
             @Override
             public void onBlockBreak(@Nonnull Block b) {
+                removeHologram(b);
+                
                 setItem(b, null);
                 setLocked(b, false);
-
-                removeHologram(b);
             }
         };
     }


### PR DESCRIPTION
Moved the removeHologram call before setItem and setLocked in onBlockBreak to ensure the hologram is removed prior to modifying block state.
https://bbs1.skycraft.cn/d/1000/